### PR TITLE
Our Hero can safely wait until recovered

### DIFF
--- a/src/buttons.js
+++ b/src/buttons.js
@@ -286,7 +286,14 @@ function buttonClicked(event) {
   if (keyPress === null) { console.log(`null keypress`); return; }
 
   if (event.srcElement.repeat) {
-    if (BUTTON_RUN.isRunning) keyPress = keyPress.toUpperCase();
+    if (BUTTON_RUN.isRunning) {
+      // Interpret "run + wait" as "rest until recovered"
+      if (keyPress == `.`) {
+        keyPress = `M`;
+      } else {
+        keyPress = keyPress.toUpperCase();
+      }
+    }
     larnmousedown(keyPress);
   } else {
     if (event.srcElement.keyboardOverride) {

--- a/src/help.js
+++ b/src/help.js
@@ -83,25 +83,25 @@ helppages[1] =
 `                       <b>Help File for The Caverns of ${GAMENAME}</b>
 
   move using             y k u                ↖ ↑ ↗
-  arrow keys             h   l       or       ←   →
-  shift+key to run       b j n                ↙ ↓ ↘       .  rest one turn
+  arrow keys             h   l       or       ←   →      .  rest one turn
+  shift+key to run       b j n                ↙ ↓ ↘      M  rest multiple turns
 
-                              A  desecrate an altar       <  go up stairs
-  c  cast a spell             C  close a door             >  go down stairs
+                              A  desecrate an altar      <  go up stairs
+  c  cast a spell             C  close a door            >  go down stairs
   d  drop an item             D  drink at a fountain
-  e  eat something            E  enter a store, dungeon   :  look at object you
-  f  tidy up at a fountain       or volcanic shaft           are standing on
+  e  eat something            E  enter a store, dungeon  :  look at object you
+  f  tidy up at a fountain       or volcanic shaft          are standing on
   g  get present pack weight                                
-  i  inventory your pockets   I  list all known items     ^  identify a trap   
+  i  inventory your pockets   I  list all known items    ^  identify a trap   
   o  open a door or chest     O  options                  
-  p  pray at an altar         P  tax status, autopray        click on an object
-  q  quaff a potion           Q  quit the game               to identify it
+  p  pray at an altar         P  tax status, autopray       click on an object
+  q  quaff a potion           Q  quit the game              to identify it
   r  read a scroll or book    R  remove gems from throne
   s  sit on a throne          S  save the game
-  t  take an item             T  take off armor           !  toggle key hints
-  v  print program version    V  view conducts            @  toggle auto-pickup
+  t  take an item             T  take off armor          !  toggle key hints
+  v  print program version    V  view conducts           @  toggle auto-pickup
   w  wield a weapon           W  wear armor
-  z  show scores              Z  teleport yourself        ?  this help screen`;
+  z  show scores              Z  teleport yourself       ?  this help screen`;
   
   // letters remaining:
   // a
@@ -109,7 +109,6 @@ helppages[1] =
   // G
   // m  move without picking 
   //    up an object
-  // M  rest for health/spells
   // x
   // X  view log history
   // /  identify objects in

--- a/src/main.js
+++ b/src/main.js
@@ -656,6 +656,76 @@ function run(dir) {
 }
 
 
+function canSeeMonster(monster) {
+  return monster.isVisible() && player.BLINDCOUNT == 0;
+}
+
+
+
+function waitUntilRecovered() {
+  let turns_waited = 0;
+  let recovering_hp = player.HP < player.HPMAX;
+  let recovering_spells = player.SPELLS < player.SPELLMAX;
+  let recovered_hp = !recovering_hp;
+  let recovered_spells = !recovering_spells;
+
+  // Don't wait if already fully recovered
+  while (recovering_hp || recovering_spells) {
+    // Stop waiting if there is a nearby awake monster the player can see
+    // (allows risky rest near monsters during stealth, hld)
+    let stop_for_monster = false;
+    for (const monster of nearbymonsters()) {
+      if (monster.awake && canSeeMonster(monster)) {
+        stop_for_monster = true;
+        break;
+      }
+    }
+    if (stop_for_monster) break;
+
+    // Wait one turn
+    turns_waited++;
+    parse2();
+
+    // Pass time
+    //
+    // (Normally, this code would run in mainloop, but here we pass multiple
+    // turns with parse2, so we need to do it here. Theoretically we should
+    // patch parse2 to update gtime, but it is a known and used exploit from the
+    // original Larn.)
+    if (player.TIMESTOP <= 0) {
+      if (player.HASTESELF == 0 || (player.HASTESELF & 1) == 0) {
+        gtime++;
+      }
+    }
+
+    // Stop waiting when health or spells are fully recovered
+    recovered_hp = player.HP == player.HPMAX;
+    recovered_spells = player.SPELLS == player.SPELLMAX;
+    if (recovering_hp && recovered_hp) break;
+    if (recovering_spells && recovered_spells) break;
+
+    // Stop waiting when hit (probably possible with haste monsters)
+    if (hitflag == 1) break;
+
+    // Stop waiting on game over and show no message (sanity check)
+    if (GAMEOVER) return;
+  }
+
+  let stop_reason;
+  if (recovered_hp && recovered_spells) {
+    stop_reason = 'fully recovered';
+  } else if (recovering_hp && recovered_hp) {
+    stop_reason = 'HP recovered';
+  } else if (recovering_spells && recovered_spells) {
+    stop_reason = 'spells recovered';
+  } else {
+    stop_reason = 'interrupted!';
+  }
+  const s = turns_waited == 1 ? '' : 's';
+  updateLog(`Waited for ${turns_waited} turn${s} - ${stop_reason}`);
+}
+
+
 
 function wizardmode(password) {
 

--- a/src/main.js
+++ b/src/main.js
@@ -514,6 +514,7 @@ function timeLeft() {
 
 
 let GLOBAL_TIMEOUT; // used for setTimeouts that can be interrupted by the main loop
+let MOVED_WORLD = false;
 
 
 
@@ -543,6 +544,7 @@ function mainloop(e, key) {
   nomove = 0;
 
   parse(e, key);
+  console.log(`mainloop: gtime=${gtime} moves=${player.MOVESMADE} MOVED_WORLD=${MOVED_WORLD}`);
 
   if (nomove == 1) {
     paint();
@@ -559,15 +561,6 @@ function mainloop(e, key) {
     return;
   }
 
-  regen(); /* regenerate hp and spells */
-  randmonst();
-
-
-  /*
-   * JRP: this is where the old main loop starts and end
-   */
-
-
   /* see if there is an object here. */
   if (dropflag == 0) {
     lookforobject(true, auto_pickup);
@@ -575,29 +568,8 @@ function mainloop(e, key) {
     dropflag = 0; /* don't show it just dropped an item */
   }
 
-  /* handle global activity
-     update game time, move spheres, move walls, move monsters
-     all the stuff affected by TIMESTOP and HASTESELF
-  */
-  if (player.TIMESTOP <= 0) {
-    if (player.HASTESELF == 0 || (player.HASTESELF & 1) == 0) {
-      gtime++;
-      /* JRP: larn12.4 start spheres 1 extra space away,
-      uncomment the code below to prevent that */
-      // if (!newsphereflag) {
-      movsphere();
-      // } else {
-      //   newsphereflag = false;
-      // }
-
-      if (hitflag == 0) {
-        if (player.HASTEMONST) {
-          movemonst();
-        }
-        movemonst();
-      }
-    }
-  }
+  if (!MOVED_WORLD) moveworld();
+  MOVED_WORLD = false;
 
   /* show stuff around the player */
   if (viewflag == 0)
@@ -623,18 +595,91 @@ function mainloop(e, key) {
 
 
 
-function parse2() {
-  /*
-   v12.4.5 - fix for monsters chasing the player even when time is stopped
-   */
-  if (player.TIMESTOP <= 0) {
-    if (player.HASTEMONST) {
+/*
+  moveworld() - handle global activity
+                update game time, move spheres, move walls, move monsters
+                all the stuff affected by TIMESTOP and HASTESELF
+*/
+/*
+  12.5.3 - many interaction between HASTESELF, HASTEMONST, and half-speed monsters
+           were buggy and inconsistent. we are now using an 8-state monster movement model 
+           using toggle flags instead of modulo.
+
+           Monster speed is determined by two independent axes:
+             - Player speed:   regular (HASTESELF==0) or fast (HASTESELF!=0)
+             - Monster speed:  slow (isSlow(), checked via isHalfTime()), normal, or hasted (HASTEMONST!=0)
+
+           "hasted monster" means HASTEMONST is active — all monsters get an extra movemonst call.
+           "slow monster"   means the individual monster's isSlow() flag — handled inside movemt() via isHalfTime().
+          
+           State table (T1–T4 = player turns 1–4; each entry is net moves for a given monster):
+             Player regular + monsters normal:        MOVE, MOVE, MOVE, MOVE   (1/turn)
+             Player regular + monsters slow:          MOVE, SKIP, MOVE, SKIP   (1/2 turns)
+             Player regular + monsters hasted:        2×MOVE every turn        (2/turn)
+             Player regular + monsters hasted+slow:   MOVE, MOVE, MOVE, MOVE   (1/turn)
+             Player fast    + monsters normal:        MOVE, SKIP, MOVE, SKIP   (1/2 turns)
+             Player fast    + monsters slow:          MOVE, SKIP, SKIP, SKIP   (1/4 turns)
+             Player fast    + monsters hasted:        MOVE, MOVE, MOVE, MOVE   (1/turn, haste cancels)
+             Player fast    + monsters hasted+slow:   MOVE, SKIP, MOVE, SKIP   (1/2 turns, matches regular+slow)
+
+           Toggles
+             player.monsterTurnToggle — flipped each moveworld call when player is fast;
+                                        baseMove fires only when this is true (every other turn).
+             player.slowMonsterToggle — flipped each time any movemonst call is dispatched
+                                        (base or extra); isHalfTime() returns !slowMonsterToggle,
+                                        so slow monsters strictly alternate move/skip across
+                                        successive movemonst calls regardless of which path fired.
+ */
+function moveworld(passtime = true) {
+
+  /* 
+    we are in an event-driven system, and every key press triggers mainloop() which
+    calls moveworld(). this is usually ok, but not after run(), player sleep, and
+    a couple of hitbymagic cases
+  */
+  MOVED_WORLD = true;
+
+  if (player.TIMESTOP === 0) {
+
+    regen(); /* regenerate hp and spells every move unless time is stopped */
+
+    const playerFast = player.HASTESELF !== 0;
+    const monstFast  = player.HASTEMONST !== 0;
+
+    let baseMove = true; /* true on every turn for a regular player, alternates true/false for a fast player */
+    if (playerFast) {
+      player.monsterTurnToggle = !player.monsterTurnToggle;
+      baseMove = player.monsterTurnToggle;
+    }
+
+    if (baseMove) {
+      /* Flip the slow-monster toggle BEFORE calling movemonst so that
+         isHalfTime() sees the updated value for this round. */
+      player.slowMonsterToggle = !player.slowMonsterToggle;
+      if (passtime) gtime++;
+      /* JRP: larn12.4 start spheres 1 extra space away,
+              uncomment the code below to prevent that */
+      // if (!newsphereflag) {
+      movsphere();
+      // } else {
+      //   newsphereflag = false;
+      // }
       movemonst();
     }
-    movemonst(); /* move the monsters */
+
+    /* Extra movemonst for hasted monsters (HASTEMONST):
+         Regular player: base already fired this turn, extra fires too       → 2 calls/turn
+         Fast player:    base fires on odd turns, extra fires on even turns  → 1 call/turn (cancels haste)
+       slowMonsterToggle is flipped before every movemonst call (base and extra) so that
+       isHalfTime() strictly alternates, giving the correct slow-monster rate in all 8 states. */
+    if (monstFast && (!playerFast || !baseMove)) {
+      player.slowMonsterToggle = !player.slowMonsterToggle;
+      movemonst();
+    }
+
     randmonst();
+
   }
-  regen();
 }
 
 
@@ -644,7 +689,7 @@ function run(dir) {
   while (i == 1) {
     i = moveplayer(dir);
     if (i > 0) {
-      parse2();
+      moveworld(false); // don't advance time when running
     }
     if (hitflag == 1) {
       i = 0;
@@ -654,6 +699,7 @@ function run(dir) {
     }
   }
 }
+
 
 
 function canSeeMonster(monster) {
@@ -684,19 +730,7 @@ function waitUntilRecovered() {
 
     // Wait one turn
     turns_waited++;
-    parse2();
-
-    // Pass time
-    //
-    // (Normally, this code would run in mainloop, but here we pass multiple
-    // turns with parse2, so we need to do it here. Theoretically we should
-    // patch parse2 to update gtime, but it is a known and used exploit from the
-    // original Larn.)
-    if (player.TIMESTOP <= 0) {
-      if (player.HASTESELF == 0 || (player.HASTESELF & 1) == 0) {
-        gtime++;
-      }
-    }
+    moveworld();
 
     // Stop waiting when health or spells are fully recovered
     recovered_hp = player.HP == player.HPMAX;
@@ -713,16 +747,18 @@ function waitUntilRecovered() {
 
   let stop_reason;
   if (recovered_hp && recovered_spells) {
-    stop_reason = 'fully recovered';
+    stop_reason = `You are fully recovered${period}`;
   } else if (recovering_hp && recovered_hp) {
-    stop_reason = 'HP recovered';
+    stop_reason = `Your health is recovered${period}`;
   } else if (recovering_spells && recovered_spells) {
-    stop_reason = 'spells recovered';
+    stop_reason = `Your spells are recovered${period}`;
   } else {
-    stop_reason = 'interrupted!';
+    stop_reason = `Your rest was interrupted!`;
+    console.log(`waitUntilRecovered: ${hitflag} ${recovered_hp} ${recovered_spells}`);
   }
   const s = turns_waited == 1 ? '' : 's';
-  updateLog(`Waited for ${turns_waited} turn${s} - ${stop_reason}`);
+  updateLog(`Rested for ${turns_waited} turn${s}${period}`);
+  updateLog(`  ${stop_reason}`);
 }
 
 

--- a/src/movem.js
+++ b/src/movem.js
@@ -742,10 +742,8 @@ function noticeplayer() {
 
 
 /*
- v12.4.5 - fix for half speed monsters following at 1:1 or not at all when running
+ v12.5.3 - fix for half speed monsters not moving properly with HASTSELF/HASTMONST
  */
 function isHalfTime() {
-  // TODO: IS THIS THE PLACE TO FIX 1/2 SPEED MONSTERS NOT WORKING WITH HASTE?
-  return (player.MOVESMADE & 1) == 1;
-  // if ((gtime & 1) == 1) // old code
+  return !player.slowMonsterToggle;
 }

--- a/src/parse.js
+++ b/src/parse.js
@@ -590,27 +590,15 @@ async function parse(e, key) {
   }
 
 
-  /*
   // 
-  // wait 'M'ultiple turns until healed or monster
+  // v12.5.4: wait 'M'ultiple turns until recovered or interrupted
   //
   if (key == 'M') {
-    if (player.TIMESTOP == 0) {
-      viewflag = 1;
-      // if health != max, restingforhealth = true
-      // if spells != max, restingforspells = true
-      // while 
-      //   if (restingforhealth & health = max stop)
-      //   if (restingfor spells & spells = max stop)
-      //   if (neither of those, rest for 100 moves?)
-      //   if nearbymonst() and awake stop (allows risky rest near monsters during stealth, hld)
-      //   if hitflag stop (probably possible with haste monsters)
-      //   parse2() ? will this show stats updating?
-
-    }
+    nomove = 1;
+    viewflag = 1;
+    waitUntilRecovered();
     return;
   }
-  */
 
   //
   // OPTIONS

--- a/src/player.js
+++ b/src/player.js
@@ -119,6 +119,8 @@ var Player = function Player() {
 
   // stats
   this.MOVESMADE = 0;
+  this.monsterTurnToggle = false; /* moveworld: flips each moveworld call when player is fast; gates base movemonst */
+  this.slowMonsterToggle = false; /* moveworld: flips each time base movemonst fires; read by isHalfTime() */
   this.MONSTKILLED = 0;
   this.SPELLSCAST = 0;
 

--- a/src/potion.js
+++ b/src/potion.js
@@ -87,7 +87,7 @@ function quaffpotion(potion, set_known) {
       updateLog(`  You fall asleep. . .`);
       var sleeplen = rnd(11) - (player.CONSTITUTION >> 2) + 2;
       while (--sleeplen > 0) {
-        parse2();
+        moveworld();
         //nap(1000);
       }
       updateLog(`  You woke up!`);

--- a/src/savelev.js
+++ b/src/savelev.js
@@ -304,6 +304,8 @@ function loadPlayer(saved) {
   newPlayer.ELEVUP = saved.ELEVUP;
 
   newPlayer.MOVESMADE = saved.MOVESMADE;
+  newPlayer.monsterTurnToggle = saved.monsterTurnToggle ?? false;
+  newPlayer.slowMonsterToggle = saved.slowMonsterToggle ?? false;
   newPlayer.SPELLSCAST = saved.SPELLSCAST;
   newPlayer.MONSTKILLED = saved.MONSTKILLED;
 

--- a/src/spells.js
+++ b/src/spells.js
@@ -771,7 +771,7 @@ function direct(spnum, direction, dam, arg) {
       beep();
       arg += 2;
       while (arg-- > 0) {
-        parse2();
+        moveworld();
         //nap(1000);
       }
       return;
@@ -780,7 +780,7 @@ function direct(spnum, direction, dam, arg) {
       beep();
       arg += 2;
       while (arg-- > 0) {
-        parse2();
+        moveworld();
         //nap(1000);
       }
       return;
@@ -1007,8 +1007,7 @@ function godirect(spnum, x, y, dx, dy, dam, delay, cshow, stroverride) {
 function exitspell() {
   napping = false;
   nomove = 0;
-  gtime++; // this is pretty hacky
-  parse2(); // monsters need a chance to attack
+  moveworld(); // monsters need a chance to attack
   paint();
 }
 


### PR DESCRIPTION
Implements the `M` command to wait multiple turns until the hero has regenerated all of their HP and spells, or until interrupted by a nearby monster or taking damage.

I pretty much followed the outline from the existing TODO comment, with a few differences:

- Set the `nomove` flag, because otherwise the hero waits one additional turn after interrupted.
- I didn't implement the idea of waiting 100 turns if you were already at full HP/spells, because I wouldn't want a player to accidentally press `M` to recover while already at full HP and accidentally waste 100 turns. This way, you can always safely press `M` to make sure you're recovered without needing to checking your HP and spells first.
- Added a sanity check for game over - just in case - because otherwise the game goes into an infinite loop.
- Added a log message to communicate how long the hero waited and why they stopped. Hopefully this also makes the command pretty self-explanatory, even if someone uses it accidentally.
- Added a note in the comment saying which version this was added in, to indicate that it's not in the original Larn. I took a guess and put 12.5.4, but if you intend to release this in a different version, that's an easy change.

For now, this command is effectively undocumented in-game, like the `P` shortcut to auto-pray.

One thing I noticed that isn't specific to this PR but is related: it doesn't seem that other uses of `nearbymonst()` and `nearbymonsters()` check whether the hero can actually *see* the nearby monster (e.g. invisible monsters, blindness), which could inadvertently reveal information to the player that their character shouldn't know. I think it might make more sense to fix this across the codebase in a different PR; if you agree, I can open an issue.
