### PR TITLE
Our Hero can automatically travel to a symbol

### DIFF
--- a/src/buttons.js
+++ b/src/buttons.js
@@ -31,6 +31,7 @@ let BUTTON_CONTINUE = setButton(ACTIONS, `BUTTON_CONTINUE`, VARIABLE, SPACE, `co
 let BUTTON_YES = setButton(null, `BUTTON_YES`, FIXED, `y`, `yes`);
 let BUTTON_NO = setButton(null, `BUTTON_NO`, FIXED, `n`, `no`);
 let BUTTON_RUN = setButton(null, `BUTTON_RUN`, `verticalbutton`, null, `run`);
+let BUTTON_REST = setButton(null, `BUTTON_REST`, `verticalbutton`, null, `rest`);
 let BUTTON_RUN_INITIALIZED = false;
 
 // let currentsize = 0; // for debugging button cache
@@ -768,11 +769,13 @@ function canMoveButton(x, y) {
 function startRun() {
   BUTTON_RUN.isRunning = true;
   BUTTON_RUN.value = `Choose Direction`;
+  BUTTON_REST.value = `Rest`;
 };
 
 function endRun() {
   BUTTON_RUN.isRunning = false;
   BUTTON_RUN.value = `Hold to Run`;
+  BUTTON_REST.value = `.`;
 };
 
 function toggleRun() {

--- a/src/explore.js
+++ b/src/explore.js
@@ -1,5 +1,15 @@
 'use strict';
 
+// Is auto-explore in progress?
+let exploring = false;
+// Flag for if the player has been hit while exploring
+let exploreHitflag = 0;
+// Number of manual player inputs since the start of the last auto-explore
+let playerInputCount = 0;
+// Async function to be run after autoexplore blocking callback
+let explorerCallback = null;
+
+
 /**
  * Maze Explorer - Frontier-based algorithm for discovering a maze with fog of war
  */
@@ -7,6 +17,14 @@
 const MazeExplorer = {
   width: 67,
   height: 17,
+
+  allowFight: false,
+  allowPickup: false,
+  allowPray: false,
+  monstersBlockDestination: true,
+  stopOnTeleport: true,
+  stopOnHit: true,
+  stopOnLowHP: false,
 
   totalSteps: 0,
   path: [], // Array of {x, y} positions
@@ -25,14 +43,6 @@ const MazeExplorer = {
       { dx: -1, dy: 0 }, // left
       { dx: -1, dy: -1 }, // up-left
     ];
-  },
-
-  /**
-   * Check if a square is blocked (wall, closed door, home entrance, or trap)
-   */
-  isBlocked: function (x, y) {
-    if (!inBounds(x, y)) return true;
-    return itemAt(x, y).matches(OWALL) || itemAt(x, y).matches(OCLOSEDDOOR) || itemAt(x, y).matches(OHOMEENTRANCE) || itemAt(x, y).isTrap();
   },
 
   /**
@@ -79,14 +89,17 @@ const MazeExplorer = {
   },
 
   /**
-   * Find nearest frontier square using BFS through known safe terrain
-   * Returns {target: {x, y}, path: [{x, y}, ...]} or null if no frontier
+   * Find the shortest path to a square matching the given destination criteria
+   * using BFS through known safe terrain
+   * Returns {target: {x, y}, path: [{x, y}, ...]} or null if path not found
    */
-  findNearestFrontier: function () {
-    const frontier = this.getFrontier();
-    if (frontier.length === 0) return null;
+  findPath: function () {
+    // If we're already at a destination, return an empty path
+    if (this.isDestination(player.x, player.y)) {
+      return [];
+    }
 
-    // BFS to find nearest frontier square
+    // Breadth-first search
     const queue = [{ x: player.x, y: player.y, path: [] }];
     const visited = new Set([`${player.x},${player.y}`]);
 
@@ -106,16 +119,13 @@ const MazeExplorer = {
         visited.add(k);
         const newPath = [...current.path, { x: nx, y: ny }];
 
-        // Check if moving here will discover a frontier square
-        const willDiscover = this.getDirections().some((dir) => {
-          return this.isFrontier(nx + dir.dx, ny + dir.dy);
-        });
-
-        if (willDiscover) {
-          return {
-            target: { x: nx, y: ny },
-            path: newPath,
-          };
+        // If this is a valid destination, return the path we found
+        if (this.isDestination(nx, ny)) {
+          // Skip if monsters are configured to block the destination
+          // Note: invisible monsters obscure the destination tile under them,
+          // so they DO block it (we don't want to give away what tile it is)
+          if (this.monstersBlockDestination && monsterAt(nx, ny)) continue;
+          return newPath;
         }
 
         queue.push({ x: nx, y: ny, path: newPath });
@@ -126,23 +136,37 @@ const MazeExplorer = {
   },
 
   /**
+   * Check if moving here will discover a frontier square
+   */
+  willDiscover: function (x, y) {
+    return this.getDirections().some((dir) => {
+      return this.isFrontier(x + dir.dx, y + dir.dy);
+    });
+  },
+
+  /**
    * Execute one step of exploration
    * Returns true if moved, false if exploration complete
    */
   step: async function () {
-    const nearest = this.findNearestFrontier();
+    const path = this.findPath();
 
-    if (!nearest) {
-      return false; // No more frontier - exploration complete
+    if (!path) {
+      return false; // Path not found; quit
     }
 
-    // Move to first step in path toward position that will discover frontier
-    if (nearest.path.length > 0) {
-      const nextPos = nearest.path[0];
+    // Move to first step in path toward destination
+    if (path.length > 0) {
+      const nextPos = path[0];
 
-      const monsters = nearbymonsters();
-      if (!this.shouldStopForMonster(monsters)) {
-        return false;
+      // Stop if a seen monster is next to the player or the next step along the path
+      const monsters = this.monstersAdjacentTo(player.x, player.y);
+      const monstersAhead = this.monstersAdjacentTo(nextPos.x, nextPos.y);
+      for (const monster of monsters + monstersAhead) {
+        if (this.shouldStopForMonster(monster)) {
+          console.log(`baddy nearby, stopping exploration.`);
+          return false;
+        }
       }
 
       // attack nearest monster, or go for nearby item
@@ -153,7 +177,7 @@ const MazeExplorer = {
         nextPos.x = monster.x;
         nextPos.y = monster.y;
         fight = true;
-      } else {
+      } else if (this.allowPickup) {
         const item = this.targetNearestItem();
         if (item) {
           await nap(300);
@@ -171,31 +195,40 @@ const MazeExplorer = {
 
       // hit the key and make the move
       simulateKeypress(key);
+      this.totalSteps++;
 
-      // trap or teleport
+      // trapdoor, teleport, or home entrance
       if (level !== currentlevel) {
         console.log(`Level changed, stopping exploration.`);
         return false;
       }
-      // teleport on same level
+      // teleport on same level, or unintentionally hit an unseen monster
       if ((player.x !== nextPos.x || player.y !== nextPos.y) && !fight) {
-        console.log(`did we teleport?`);
-        // console.log(`did we teleport? stopping exploration.`);
-        // return false;
-        await nap(1000);
+        if (this.stopOnTeleport) {
+          console.log(`Position changed unexpectedly, stopping exploration.`);
+          return false;
+        } else {
+          console.log(`Position changed unexpectedly.`);
+          await nap(1000);
+        }
       }
+      if (this.stopOnHit && exploreHitflag == 1) {
+        console.log(`Player hit, stopping exploration.`);
+        return false;
+      }
+      exploreHitflag = false;
       // too low on HP
-      if (player.HP < player.HPMAX / 2) {
+      if (this.stopOnLowHP && player.HP < player.HPMAX / 2) {
         console.log(`Player HP low, stopping exploration.`);
         return false;
       }
       // pick up item if present
       const item = itemAt(player.x, player.y);
-      if (canTake(item) && !pocketfull() && !item.matches(OCOOKIE)) {
+      if (this.allowPickup && canTake(item) && !pocketfull() && !item.matches(OCOOKIE)) {
         simulateKeypress('t');
       }
       // auto-pray at altar if we have enough gold
-      if (itemAt(player.x, player.y).matches(OALTAR)) {
+      if (this.allowPray && itemAt(player.x, player.y).matches(OALTAR)) {
         if (player.GOLD >= 50) {
           autoPray();
         } else {
@@ -208,7 +241,6 @@ const MazeExplorer = {
       // stop to admire the view
       await nap(10);
 
-      this.totalSteps++;
       this.path.push(nextPos);
       return true;
     }
@@ -216,15 +248,23 @@ const MazeExplorer = {
     return false;
   },
 
-  shouldStopForMonster: function (monsters) {
-    for (let i = 0; i < monsters.length; i++) {
-      const monster = monsters[i];
-      if (monster.attack > 0) {
-        console.log(`baddy nearby, stopping exploration.`);
-        return false;
+
+  // Return seen monsters adjacent to the given coordinates
+  monstersAdjacentTo: function (x, y) {
+    const monsters = [];
+    for (let tmpx = vx(x - 1); tmpx <= vx(x + 1); tmpx++) {
+      for (let tmpy = vy(y - 1); tmpy <= vy(y + 1); tmpy++) {
+        const monster = monsterAt(tmpx, tmpy);
+        if (monster && canSeeMonster(monster) && getKnow(x, y) & KNOWHERE) {
+          monsters.push(monster);
+        }
       }
     }
-    return true;
+    return monsters;
+  },
+
+  shouldStopForMonster: function (monster) {
+    return !this.allowFight || monster.attack > 0;
   },
 
   targetNearestMonster: function (monsters) {
@@ -236,7 +276,7 @@ const MazeExplorer = {
       y = player.y + diroffy[k];
       if (!inBounds(x, y)) continue;
       const monster = monsterAt(x, y);
-      if (monster) {
+      if (monster && canSeeMonster(monster)) {
         if (monster.matches(BAT) && i == 0 && monsters.length > 1) {
           console.log(`skipping bat`);
           continue; // leave the first bat for later
@@ -276,19 +316,71 @@ const MazeExplorer = {
   },
 
   /**
-   * Run full exploration and return results
-   * Returns {steps: number, path: [{x, y}, ...], discoveredCount: number}
+   * Explore until complete or interrupted.
+   * Returns {success: bool, interrupted: bool, steps: number, path: [{x, y}, ...], discoveredCount: number}
    */
   explore: async function () {
-    while (await this.step()) {
-      // Keep stepping until exploration is complete
+    exploring = true;
+    exploreHitflag = false;
+    playerInputCount = 0;
+    const auto_pickup_state = auto_pickup;
+    auto_pickup = false;
+
+    while (playerInputCount == 0 && await this.step()) {
+      // Keep stepping until exploration is complete or interrupted
     }
 
+    auto_pickup = auto_pickup_state;
+    exploring = false;
+
     return {
+      success: this.isDestination(player.x, player.y),
+      interrupted: playerInputCount != 0,
       steps: this.totalSteps,
       path: this.path,
       discoveredCount: this.getDiscoveredCount(),
     };
+  },
+
+  /**
+   * Does the given item match of the items in the given array?
+   */
+  matchesAny: function (item, items) {
+    return items.some((exact) => item.matches(exact))
+  },
+
+  /**
+   * Set up MazeExplorer to automatically explore the current level
+   */
+  setupExplore: function () {
+    this.allowFight = true;
+    this.allowPickup = true;
+    this.allowPray = true;
+    this.stopOnTeleport = false;
+    this.stopOnHit = false;
+    this.stopOnLowHP = true;
+    this.monstersBlockDestination = false;
+    this.isDestination = (x, y) => this.willDiscover(x, y);
+    this.isBlocked = (x, y) => (
+      !inBounds(x, y) ||
+      this.matchesAny(itemAt(x, y), [OWALL, OCLOSEDDOOR, OHOMEENTRANCE]) ||
+      itemAt(x, y).isTrap()
+    );
+  },
+
+  /**
+   * Set up MazeExplorer to travel to the nearest instance of any of the given items
+   */
+  setupTravelToItem: function (items) {
+    this.isDestination = (x, y) => this.matchesAny(itemAt(x, y), items);
+    this.isBlocked = (x, y) => (
+      !inBounds(x, y) || (
+        !this.isDestination(x, y) && (
+          this.matchesAny(itemAt(x, y), [OWALL, OCLOSEDDOOR, OHOMEENTRANCE, OALTAR]) ||
+          itemAt(x, y).isTrap()
+        )
+      )
+    );
   },
 
   /**
@@ -337,6 +429,169 @@ const MazeExplorer = {
     };
   },
 };
+
+
+
+/**
+ * Returns each item whose symbol matches the given key press.
+ */
+function parseItemsBySymbol(key) {
+  const candidateObjects = [
+    OHOMEENTRANCE,
+
+    // buildings / home level
+    OHOME,
+    ODNDSTORE,
+    OTRADEPOST,
+    OLRS,
+    OBANK,
+    OBANK2,
+    OSCHOOL,
+    OENTRANCE,
+    OVOLDOWN,
+    // ULARN
+    OPAD,
+
+    // dungeon features
+    OALTAR,
+    OTHRONE,
+    ODEADTHRONE,
+    OPIT,
+    OVOLUP,
+    OSTAIRSUP,
+    OSTAIRSDOWN,
+    OFOUNTAIN,
+    ODEADFOUNTAIN,
+    OSTATUE,
+    OMIRROR,
+    OOPENDOOR,
+    OCLOSEDDOOR,
+    // ULARN
+    OELEVATORUP,
+    OELEVATORDOWN,
+
+    // traps
+    OTELEPORTER,
+    OTRAPARROW,
+    ODARTRAP,
+    OTRAPDOOR,
+
+    // dungeon items
+    OGOLDPILE,
+    OSCROLL,
+    OPOTION,
+    OBOOK,
+    OCHEST,
+    ODIAMOND,
+    ORUBY,
+    OEMERALD,
+    OSAPPHIRE,
+
+    // weapons
+    OSWORD,
+    O2SWORD,
+    OSPEAR,
+    ODAGGER,
+    OBELT,
+    OBATTLEAXE,
+    OLONGSWORD,
+    OFLAIL,
+    OLANCE,
+
+    // special weapons
+    OSWORDofSLASHING,
+    OHAMMER,
+    // ULARN
+    OVORPAL,
+    OSLAYER,
+
+    // armour
+    OLEATHER,
+    OSTUDLEATHER,
+    ORING,
+    OCHAIN,
+    OSPLINT,
+    OPLATE,
+    OPLATEARMOR,
+    OSSPLATE,
+    OSHIELD,
+    // ULARN
+    OELVENCHAIN,
+
+    // rings
+    ORINGOFEXTRA,
+    OREGENRING,
+    OPROTRING,
+    OENERGYRING,
+    ODEXRING,
+    OSTRRING,
+    OCLEVERRING,
+    ODAMRING,
+
+    // special objects
+    OLARNEYE,
+    OAMULET,
+    OORBOFDRAGON,
+    OSPIRITSCARAB,
+    OCUBEofUNDEAD,
+    ONOTHEFT,
+    OORB,
+    // ULARN
+    OBRASSLAMP,
+    OHANDofFEAR,
+    OSPHTALISMAN,
+    OWWAND,
+    OPSTAFF,
+    OLIFEPRESERVER,
+
+    // ULARN drugs
+    OSPEED,
+    OACID,
+    OHASH,
+    OSHROOMS,
+    OCOKE
+  ];
+
+  return candidateObjects.filter(
+    (candidate) => (
+      original_objects ? (ULARN ? candidate.ularnchar : candidate.char) : candidate.hackchar
+    ) == key
+  );
+}
+
+
+
+function parseTravelToItem(key) {
+  if (key == ESC) {
+    appendLog(` cancelled${period}`);
+  } else {
+    const items = parseItemsBySymbol(key);
+    if (items.length > 0) {
+      const explorer = Object.create(MazeExplorer);
+      explorer.setupTravelToItem(items);
+      explorerCallback = travelToItemCallback.bind(null, explorer);
+    } else {
+      updateLog(`I can't travel to that symbol!`);
+    }
+  }
+  return exitbuilding();
+}
+
+
+async function travelToItemCallback(explorer) {
+  const result = await explorer.explore();
+  if (result.steps == 0 && !result.interrupted) {
+    if (result.success) {
+      // If the player is already at the destination, look at the tile to make this clearer
+      lookforobject(true, false);
+    } else {
+      updateLog(`  I see no safe path to that symbol!`);
+    }
+    paint();
+  }
+}
+
+
 
 // Export for use in Node.js or browser
 if (typeof module !== 'undefined' && module.exports) {

--- a/src/explore.js
+++ b/src/explore.js
@@ -34,14 +34,14 @@ const MazeExplorer = {
    */
   getDirections: function () {
     return [
-      { dx: 0, dy: -1 }, // up
-      { dx: 1, dy: -1 }, // up-right
-      { dx: 1, dy: 0 }, // right
-      { dx: 1, dy: 1 }, // down-right
-      { dx: 0, dy: 1 }, // down
-      { dx: -1, dy: 1 }, // down-left
       { dx: -1, dy: 0 }, // left
+      { dx: 1, dy: 0 }, // right
+      { dx: 0, dy: -1 }, // up
+      { dx: 0, dy: 1 }, // down
       { dx: -1, dy: -1 }, // up-left
+      { dx: 1, dy: -1 }, // up-right
+      { dx: -1, dy: 1 }, // down-left
+      { dx: 1, dy: 1 }, // down-right
     ];
   },
 
@@ -165,6 +165,8 @@ const MazeExplorer = {
       for (const monster of monsters + monstersAhead) {
         if (this.shouldStopForMonster(monster)) {
           console.log(`baddy nearby, stopping exploration.`);
+          updateLog(`  Travel interrupted!`);
+          paint();
           return false;
         }
       }
@@ -180,7 +182,7 @@ const MazeExplorer = {
       } else if (this.allowPickup) {
         const item = this.targetNearestItem();
         if (item) {
-          await nap(300);
+          await nap(150);
           nextPos.x = item.x;
           nextPos.y = item.y;
         }
@@ -264,6 +266,7 @@ const MazeExplorer = {
   },
 
   shouldStopForMonster: function (monster) {
+    // return (!this.allowFight || monster.attack > 0) && (player.AGGRAVATE || !player.STEALTH || monster.awake); // too aggro - fights when stealthy but !allowfight
     return !this.allowFight || monster.attack > 0;
   },
 
@@ -323,14 +326,11 @@ const MazeExplorer = {
     exploring = true;
     exploreHitflag = false;
     playerInputCount = 0;
-    const auto_pickup_state = auto_pickup;
-    auto_pickup = false;
 
     while (playerInputCount == 0 && await this.step()) {
       // Keep stepping until exploration is complete or interrupted
     }
 
-    auto_pickup = auto_pickup_state;
     exploring = false;
 
     return {
@@ -363,7 +363,8 @@ const MazeExplorer = {
     this.isDestination = (x, y) => this.willDiscover(x, y);
     this.isBlocked = (x, y) => (
       !inBounds(x, y) ||
-      this.matchesAny(itemAt(x, y), [OWALL, OCLOSEDDOOR, OHOMEENTRANCE]) ||
+      (!player.WTW && this.matchesAny(itemAt(x, y), [OWALL, OCLOSEDDOOR])) ||
+      this.matchesAny(itemAt(x, y), [OHOMEENTRANCE]) ||
       itemAt(x, y).isTrap()
     );
   },
@@ -376,7 +377,8 @@ const MazeExplorer = {
     this.isBlocked = (x, y) => (
       !inBounds(x, y) || (
         !this.isDestination(x, y) && (
-          this.matchesAny(itemAt(x, y), [OWALL, OCLOSEDDOOR, OHOMEENTRANCE, OALTAR]) ||
+          (!player.WTW && this.matchesAny(itemAt(x, y), [OWALL, OCLOSEDDOOR])) ||
+          this.matchesAny(itemAt(x, y), [OHOMEENTRANCE, OALTAR]) ||
           itemAt(x, y).isTrap()
         )
       )
@@ -436,123 +438,7 @@ const MazeExplorer = {
  * Returns each item whose symbol matches the given key press.
  */
 function parseItemsBySymbol(key) {
-  const candidateObjects = [
-    OHOMEENTRANCE,
-
-    // buildings / home level
-    OHOME,
-    ODNDSTORE,
-    OTRADEPOST,
-    OLRS,
-    OBANK,
-    OBANK2,
-    OSCHOOL,
-    OENTRANCE,
-    OVOLDOWN,
-    // ULARN
-    OPAD,
-
-    // dungeon features
-    OALTAR,
-    OTHRONE,
-    ODEADTHRONE,
-    OPIT,
-    OVOLUP,
-    OSTAIRSUP,
-    OSTAIRSDOWN,
-    OFOUNTAIN,
-    ODEADFOUNTAIN,
-    OSTATUE,
-    OMIRROR,
-    OOPENDOOR,
-    OCLOSEDDOOR,
-    // ULARN
-    OELEVATORUP,
-    OELEVATORDOWN,
-
-    // traps
-    OTELEPORTER,
-    OTRAPARROW,
-    ODARTRAP,
-    OTRAPDOOR,
-
-    // dungeon items
-    OGOLDPILE,
-    OSCROLL,
-    OPOTION,
-    OBOOK,
-    OCHEST,
-    ODIAMOND,
-    ORUBY,
-    OEMERALD,
-    OSAPPHIRE,
-
-    // weapons
-    OSWORD,
-    O2SWORD,
-    OSPEAR,
-    ODAGGER,
-    OBELT,
-    OBATTLEAXE,
-    OLONGSWORD,
-    OFLAIL,
-    OLANCE,
-
-    // special weapons
-    OSWORDofSLASHING,
-    OHAMMER,
-    // ULARN
-    OVORPAL,
-    OSLAYER,
-
-    // armour
-    OLEATHER,
-    OSTUDLEATHER,
-    ORING,
-    OCHAIN,
-    OSPLINT,
-    OPLATE,
-    OPLATEARMOR,
-    OSSPLATE,
-    OSHIELD,
-    // ULARN
-    OELVENCHAIN,
-
-    // rings
-    ORINGOFEXTRA,
-    OREGENRING,
-    OPROTRING,
-    OENERGYRING,
-    ODEXRING,
-    OSTRRING,
-    OCLEVERRING,
-    ODAMRING,
-
-    // special objects
-    OLARNEYE,
-    OAMULET,
-    OORBOFDRAGON,
-    OSPIRITSCARAB,
-    OCUBEofUNDEAD,
-    ONOTHEFT,
-    OORB,
-    // ULARN
-    OBRASSLAMP,
-    OHANDofFEAR,
-    OSPHTALISMAN,
-    OWWAND,
-    OPSTAFF,
-    OLIFEPRESERVER,
-
-    // ULARN drugs
-    OSPEED,
-    OACID,
-    OHASH,
-    OSHROOMS,
-    OCOKE
-  ];
-
-  return candidateObjects.filter(
+  return itemlist.filter(
     (candidate) => (
       original_objects ? (ULARN ? candidate.ularnchar : candidate.char) : candidate.hackchar
     ) == key
@@ -562,30 +448,35 @@ function parseItemsBySymbol(key) {
 
 
 function parseTravelToItem(key) {
+  // TODO: how do we handle ULARN stairs? up and down are both %
+  // TODO: should we have separate { } commands for the stairs?
+  if (key === `<`) key = `&lt`;
+  if (key === `>`) key = `&gt`;
   if (key == ESC) {
     appendLog(` cancelled${period}`);
   } else {
     const items = parseItemsBySymbol(key);
+    echo(key);
     if (items.length > 0) {
       const explorer = Object.create(MazeExplorer);
       explorer.setupTravelToItem(items);
-      explorerCallback = travelToItemCallback.bind(null, explorer);
+      explorerCallback = travelToItemCallback.bind(null, explorer, key);
     } else {
-      updateLog(`I can't travel to that symbol!`);
+      updateLog(`  Unknown object${period}`);
     }
   }
-  return exitbuilding();
+  return 1;
 }
 
 
-async function travelToItemCallback(explorer) {
+async function travelToItemCallback(explorer, key) {
   const result = await explorer.explore();
   if (result.steps == 0 && !result.interrupted) {
     if (result.success) {
       // If the player is already at the destination, look at the tile to make this clearer
       lookforobject(true, false);
     } else {
-      updateLog(`  I see no safe path to that symbol!`);
+      updateLog(`  No path found${period}`);
     }
     paint();
   }

--- a/src/help.js
+++ b/src/help.js
@@ -91,7 +91,7 @@ helppages[1] =
   d  drop an item             D  drink at a fountain
   e  eat something            E  enter a store, dungeon  :  look at object you
   f  tidy up at a fountain       or volcanic shaft          are standing on
-  g  get present pack weight                                
+  g  get present pack weight  G  go to item                              
   i  inventory your pockets   I  list all known items    ^  identify a trap   
   o  open a door or chest     O  options                  
   p  pray at an altar         P  tax status, autopray       click on an object
@@ -106,13 +106,14 @@ helppages[1] =
   // letters remaining:
   // a
   // F
-  // G
   // m  move without picking 
   //    up an object
   // x
   // X  view log history
   // /  identify objects in
   //    the game 
+  // {  travel to up stairs
+  // }  travel to down stairs
 
 
 helppages[2] =

--- a/src/larn.js
+++ b/src/larn.js
@@ -134,11 +134,10 @@ function initKeyBindings() {
   Mousetrap.bind('<', mousetrap); // go up
   Mousetrap.bind('>', mousetrap); // go down
   Mousetrap.bind('^', mousetrap); // identify traps
+  Mousetrap.bind(':', mousetrap); // examine
   Mousetrap.bind('!', mousetrap); // keyboard hints
   Mousetrap.bind('@', mousetrap); // auto-pickup
   // Mousetrap.bind('#', mousetrap); // inventory 
-  // Mousetrap.bind('{', mousetrap); // retro fonts
-  // Mousetrap.bind('}', mousetrap); // classic/hack/amiga 
   Mousetrap.bind('?', mousetrap); // help
   Mousetrap.bind('_', mousetrap); // password
   Mousetrap.bind('-', mousetrap); // disarm 
@@ -174,10 +173,9 @@ function initKeyBindings() {
   Mousetrap.bind('*', mousetrap);
   Mousetrap.bind(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'], mousetrap);
 
-  Mousetrap.bind([':'], mousetrap);
 
   // Item symbols for autotravel
-  Mousetrap.bind(['=', '$', '\\', '%', '{', '|', '\'', '&', '[', ']', '~', '}', ';', '"'], mousetrap);
+  Mousetrap.bind(['=', '$', '\\', '/', '%', '{', '|', '\'', '&', '[', ']', '~', '}', ';', '"'], mousetrap);
 }
 
 

--- a/src/larn.js
+++ b/src/larn.js
@@ -175,6 +175,9 @@ function initKeyBindings() {
   Mousetrap.bind(['0', '1', '2', '3', '4', '5', '6', '7', '8', '9'], mousetrap);
 
   Mousetrap.bind([':'], mousetrap);
+
+  // Item symbols for autotravel
+  Mousetrap.bind(['=', '$', '\\', '%', '{', '|', '\'', '&', '[', ']', '~', '}', ';', '"'], mousetrap);
 }
 
 

--- a/src/main.js
+++ b/src/main.js
@@ -604,6 +604,7 @@ function mainloop(e, key) {
     showcell(player.x, player.y);
 
   viewflag = 0;
+  exploreHitflag |= hitflag; // JS Larn: copy hitflag for use in explore code
   hitflag = 0;
 
   if (gtime >= 400 && gtime % 400 == 0) {
@@ -653,6 +654,12 @@ function run(dir) {
       showcell(player.x, player.y);
     }
   }
+}
+
+
+
+function canSeeMonster(monster) {
+  return monster.isVisible() && player.BLINDCOUNT == 0;
 }
 
 

--- a/src/main.js
+++ b/src/main.js
@@ -544,7 +544,6 @@ function mainloop(e, key) {
   nomove = 0;
 
   parse(e, key);
-  console.log(`mainloop: gtime=${gtime} moves=${player.MOVESMADE} MOVED_WORLD=${MOVED_WORLD}`);
 
   if (nomove == 1) {
     paint();
@@ -608,10 +607,10 @@ function mainloop(e, key) {
 
            Monster speed is determined by two independent axes:
              - Player speed:   regular (HASTESELF==0) or fast (HASTESELF!=0)
-             - Monster speed:  slow (isSlow(), checked via isHalfTime()), normal, or hasted (HASTEMONST!=0)
+             - Monster speed:  slow (isSlow()), normal, or hasted (HASTEMONST!=0)
 
-           "hasted monster" means HASTEMONST is active — all monsters get an extra movemonst call.
-           "slow monster"   means the individual monster's isSlow() flag — handled inside movemt() via isHalfTime().
+           "hasted monster" means HASTEMONST is active
+           "slow monster"   means the individual monster isSlow()
           
            State table (T1–T4 = player turns 1–4; each entry is net moves for a given monster):
              Player regular + monsters normal:        MOVE, MOVE, MOVE, MOVE   (1/turn)
@@ -620,8 +619,8 @@ function mainloop(e, key) {
              Player regular + monsters hasted+slow:   MOVE, MOVE, MOVE, MOVE   (1/turn)
              Player fast    + monsters normal:        MOVE, SKIP, MOVE, SKIP   (1/2 turns)
              Player fast    + monsters slow:          MOVE, SKIP, SKIP, SKIP   (1/4 turns)
-             Player fast    + monsters hasted:        MOVE, MOVE, MOVE, MOVE   (1/turn, haste cancels)
-             Player fast    + monsters hasted+slow:   MOVE, SKIP, MOVE, SKIP   (1/2 turns, matches regular+slow)
+             Player fast    + monsters hasted:        MOVE, MOVE, MOVE, MOVE   (1/turn)
+             Player fast    + monsters hasted+slow:   MOVE, SKIP, MOVE, SKIP   (1/2 turns)
 
            Toggles
              player.monsterTurnToggle — flipped each moveworld call when player is fast;
@@ -755,7 +754,6 @@ function waitUntilRecovered() {
     stop_reason = `Your spells are recovered${period}`;
   } else {
     stop_reason = `Your rest was interrupted!`;
-    console.log(`waitUntilRecovered: ${hitflag} ${recovered_hp} ${recovered_spells}`);
   }
   const s = turns_waited == 1 ? '' : 's';
   updateLog(`Rested for ${turns_waited} turn${s}${period}`);

--- a/src/monster.js
+++ b/src/monster.js
@@ -321,7 +321,7 @@ Monster.prototype = {
       case XVART:
       case INVISIBLESTALKER:
       case ICELIZARD:
-        // if (isHalfTime()) return;
+        if (isHalfTime()) return;
         return true;
     }
     return false;

--- a/src/movem.js
+++ b/src/movem.js
@@ -129,7 +129,7 @@ function movemt(x, y) {
   }
 
   /* half speed monsters only move every other turn */
-  if (monster.isSlow() && isHalfTime()) {
+  if (monster.isSlow()) {
     return;
   }
 

--- a/src/parse.js
+++ b/src/parse.js
@@ -63,12 +63,14 @@ Mousetrap.prototype.handleKey = function (char, mod, evt) {
 function simulateKeypress(key) {
   // code/keyCode/which are incorrect, but not needed for our purposes
   mousetrap(new KeyboardEvent('keydown', { key: key, code: '', keyCode: 0, which: 0, bubbles: true }), key);
+  playerInputCount--;
 }
 
 
 
 function mousetrap(e, key) {
   // debug(`mousetrap: ${key} ${JSON.stringify(e)}`);
+  playerInputCount++;
   if (key == SPACE) key = ' ';
   if (key == TAB) return false;
 
@@ -199,6 +201,16 @@ async function parse(e, key) {
     // i think i have created my own special callback hell
     if (before == after && done) {
       blocking_callback = null;
+
+      // Handle autotravel here
+      // This is a bit ugly, but it needs to be awaited, which can't be done from the blocking callback
+      if (explorerCallback) {
+        nomove = 1;
+        const tmpCallback = explorerCallback;
+        explorerCallback = null;
+        await tmpCallback();
+        return;
+      }
     }
     if (!done) {
       nomove = 1;
@@ -865,6 +877,16 @@ async function parse(e, key) {
   }
 
   //
+  // 'G'o to the specified symbol
+  //
+  if (key == 'G') {
+    nomove = 1;
+    updateLog(`What symbol do you want to travel to? `);
+    setCharCallback(parseTravelToItem);
+    return;
+  }
+
+  //
   // wizard mode
   //
   if (key == '_') {
@@ -878,10 +900,14 @@ async function parse(e, key) {
   //  MAZE EXPLORER
   //
   if (debug_used && key === '±') {
-    const explorer = Object.create(MazeExplorer);
-    const result = await explorer.explore();
-    console.log(`Explored in ${result.steps} steps`);
-    return;
+    nomove = 1;
+    if (!exploring) {
+      const explorer = Object.create(MazeExplorer);
+      explorer.setupExplore();
+      const result = await explorer.explore();
+      console.log(`Explored in ${result.steps} steps`);
+      return;
+    }
   }
 
   //

--- a/src/parse.js
+++ b/src/parse.js
@@ -206,7 +206,7 @@ async function parse(e, key) {
       // This is a bit ugly, but it needs to be awaited, which can't be done from the blocking callback
       if (explorerCallback) {
         nomove = 1;
-        const tmpCallback = explorerCallback;
+        const tmpCallback = explorerCallback; // avoid re-entrancy bug
         explorerCallback = null;
         await tmpCallback();
         return;
@@ -592,6 +592,16 @@ async function parse(e, key) {
   }
 
   //
+  // 'G'o to the specified symbol
+  //
+  if (key == 'G') {
+    nomove = 1;
+    updateLog(`What symbol do you want to travel to? `);
+    setCharCallback(parseTravelToItem);
+    return;
+  }
+
+  //
   // list spells and scrolls
   //
   if (key == 'I') {
@@ -861,16 +871,6 @@ async function parse(e, key) {
     auto_pickup = !auto_pickup;
     localStorageSetObject(`auto_pickup`, auto_pickup);
     updateLog(`Auto-pickup: ${auto_pickup ? `on` : `off`}`);
-    return;
-  }
-
-  //
-  // 'G'o to the specified symbol
-  //
-  if (key == 'G') {
-    nomove = 1;
-    updateLog(`What symbol do you want to travel to? `);
-    setCharCallback(parseTravelToItem);
     return;
   }
 


### PR DESCRIPTION
This PR implements the shortcut `G` ("Go") which works as follows:

- Prompts the player for a symbol
- Finds the shortest safe path to the nearest known item or dungeon feature matching that symbol
- Makes the hero automatically walk to it

This is a very convenient feature found in games like NetHack (in the form of the `_` command), and I think it will save Larn players a lot of time! At the same time, it is not a cheat - it does not do anything players couldn't do without it, nor does it reveal any hidden information.

The "autotravel" feature leverages the existing autoexplore functionality from `explore.js`, the use of which is otherwise restricted to debug mode. Like autoexplore, autotravel finds the shortest path, avoiding unexplored areas and known traps. Unlike autoexplore, however, autotravel does *not* automatically fight monsters, pick up items, or pray at altars. Instead, nearby monsters interrupt autotravel, items are ignored, and altars are avoided. Teleport traps also interrupt autotravel, even if they take you to the same level. I've made these behaviors into configurable fields so they can be easily tweaked as desired.

Since this is intended to be a feature available to all players, not just developers, I've also improved the UX for autotravel (and autoexplore) by allowing the player to interrupt it with any keypress (previously, you had to wait for autoexplore to complete in its entirety).

Feedback and suggestions are welcome!
