### PR TITLE
Our Hero can no longer stop time indefinitely

### DIFF
--- a/src/main.js
+++ b/src/main.js
@@ -639,10 +639,10 @@ function moveworld(passtime = true) {
   */
   MOVED_WORLD = true;
 
+  /* regenerate hp and spells every move; if time is stopped, it wears off by one turn */
+  regen();
+
   if (player.TIMESTOP === 0) {
-
-    regen(); /* regenerate hp and spells every move unless time is stopped */
-
     const playerFast = player.HASTESELF !== 0;
     const monstFast  = player.HASTEMONST !== 0;
 


### PR DESCRIPTION
The recent `moveworld` refactor (implemented along with #27) attempted to change the stop time spell to prevent regeneration of HP and spells by not calling the `regen` function while time is stopped. However, `regen` already accounts for timestop - if timestop is active, all it does is reduce the `TIMESTOP` counter by one. Without this call to `regen` during timestop, timestop never wears off. This also means that if you press `M` to wait until recovered while timestop is active, the game will enter an infinite loop because you will never regenerate, never be interrupted, and timestop will never wear off.

This PR simply changes `regen` to be called in `moveworld` even when `TIMESTOP` is active.
