### PR TITLE
Color code HP on status bar

### DIFF
--- a/src/common/util.js
+++ b/src/common/util.js
@@ -432,21 +432,17 @@ function padString(str, width, lastHighlightTime, color=``) {
   var spaces = Array(numspaces).join(` `);
   var shouldHighlight = ((now - lastHighlightTime) < HIGHLIGHT_DELAY);
   if (shouldHighlight) {
-	  if (color === ``) color = `lightgrey`;
-	  var markupStart = `${START_MARK}${color}'>`;
-	  var markupEnd = END_MARK;
+    var markup = wrapMark(str, color);
   } else if (color !== ``) {
-	  var markupStart = `${START_FONT}'${color}'>`;
-	  var markupEnd = END_FONT;
+    var markup = wrapFont(str, color);
   } else {
-	  var markupStart = ``;
-	  var markupEnd = ``;
+    var markup = str;
   }
 
   if (width < 0) {
-    return `${markupStart}${str}${markupEnd}${spaces}`;
+    return `${markup}${spaces}`;
   } else {
-    return `${spaces}${markupStart}${str}${markupEnd}`;
+    return `${spaces}${markup}`;
   }
 }
 

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -417,27 +417,36 @@ function isnum(str) {
 
 
 
-function pad(str, width, bold) {
-  return padString(`` + str, width, bold);
+function pad(str, width, bold, color=``) {
+  return padString(`` + str, width, bold, color);
 }
 
 
 
 const HIGHLIGHT_DELAY = 700; // left align with -width, otherwise right align
-function padString(str, width, lastHighlightTime) {
+function padString(str, width, lastHighlightTime, color=``) {
   if (!str) return Array(Math.abs(width)).join(` `);
   if (!width || width == 0) return str;
   var now = millis();
   var numspaces = Math.max(0, Math.abs(width) + 1 - str.length);
   var spaces = Array(numspaces).join(` `);
   var shouldHighlight = ((now - lastHighlightTime) < HIGHLIGHT_DELAY);
-  var highlightStart = shouldHighlight ? START_MARK : ``;
-  var highlightEnd = shouldHighlight ? END_MARK : ``;
+  if (shouldHighlight) {
+	  if (color === ``) color = `lightgrey`;
+	  var markupStart = `${START_MARK}${color}'>`;
+	  var markupEnd = END_MARK;
+  } else if (color !== ``) {
+	  var markupStart = `${START_FONT}'${color}'>`;
+	  var markupEnd = END_FONT;
+  } else {
+	  var markupStart = ``;
+	  var markupEnd = ``;
+  }
 
   if (width < 0) {
-    return `${highlightStart}${str}${highlightEnd}${spaces}`;
+    return `${markupStart}${str}${markupEnd}${spaces}`;
   } else {
-    return `${spaces}${highlightStart}${str}${highlightEnd}`;
+    return `${spaces}${markupStart}${str}${markupEnd}`;
   }
 }
 

--- a/src/common/util.js
+++ b/src/common/util.js
@@ -417,14 +417,14 @@ function isnum(str) {
 
 
 
-function pad(str, width, bold, color=``) {
+function pad(str, width, bold, color) {
   return padString(`` + str, width, bold, color);
 }
 
 
 
 const HIGHLIGHT_DELAY = 700; // left align with -width, otherwise right align
-function padString(str, width, lastHighlightTime, color=``) {
+function padString(str, width, lastHighlightTime, color) {
   if (!str) return Array(Math.abs(width)).join(` `);
   if (!width || width == 0) return str;
   var now = millis();
@@ -432,9 +432,9 @@ function padString(str, width, lastHighlightTime, color=``) {
   var spaces = Array(numspaces).join(` `);
   var shouldHighlight = ((now - lastHighlightTime) < HIGHLIGHT_DELAY);
   if (shouldHighlight) {
-    var markup = wrapMark(str, color);
-  } else if (color !== ``) {
-    var markup = wrapFont(str, color);
+    var markup = highlightText(str, color);
+  } else if (color) {
+    var markup = colorText(str, color);
   } else {
     var markup = str;
   }

--- a/src/devmode.js
+++ b/src/devmode.js
@@ -55,7 +55,7 @@ function enableDevmode() {
     // gtime = 40001;
     player.GOLD = 250000;
 
-    updateLog(`normal <i>italic</i> <s>strike</s> <b>bold</b> <dim>dim</dim> <mark>mark</mark> <u>underline</u> <a href='https://larn.org'>Link</a> <font color='red'>red</font> <font color='green'>green</font> <font color='blue'>blue</font>`);
+    updateLog(`normal <i>italic</i> <s>strike</s> <b>bold</b> <dim>dim</dim> <mark style='color:lightgrey'>mark</mark> <u>underline</u> <a href='https://larn.org'>Link</a> <font color='red'>red</font> <font color='green'>green</font> <font color='blue'>blue</font>`);
 
     // newcavelevel(level + 1);
     // setItem(player.x, player.y, createObject(OTRAPDOOR));

--- a/src/devmode.js
+++ b/src/devmode.js
@@ -55,7 +55,7 @@ function enableDevmode() {
     // gtime = 40001;
     player.GOLD = 250000;
 
-    updateLog(`normal <i>italic</i> <s>strike</s> <b>bold</b> <dim>dim</dim> <mark style='color:lightgrey'>mark</mark> <u>underline</u> <a href='https://larn.org'>Link</a> <font color='red'>red</font> <font color='green'>green</font> <font color='blue'>blue</font>`);
+    updateLog(`normal ${START_ITALIC}italic${END_ITALIC} ${START_STRIKE}strike${END_STRIKE} ${START_BOLD}bold${END_BOLD} ${START_DIM}dim${END_DIM} ${wrapMark('mark')} ${START_UNDERLINE}underline${END_UNDERLINE} ${wrapHref('Link', 'https://larn.org')} ${wrapFont('red', 'red')} ${wrapFont('green', 'green')} ${wrapFont('blue', 'blue')}`);
 
     // newcavelevel(level + 1);
     // setItem(player.x, player.y, createObject(OTRAPDOOR));

--- a/src/devmode.js
+++ b/src/devmode.js
@@ -55,7 +55,7 @@ function enableDevmode() {
     // gtime = 40001;
     player.GOLD = 250000;
 
-    updateLog(`normal ${START_ITALIC}italic${END_ITALIC} ${START_STRIKE}strike${END_STRIKE} ${START_BOLD}bold${END_BOLD} ${START_DIM}dim${END_DIM} ${wrapMark('mark')} ${START_UNDERLINE}underline${END_UNDERLINE} ${wrapHref('Link', 'https://larn.org')} ${wrapFont('red', 'red')} ${wrapFont('green', 'green')} ${wrapFont('blue', 'blue')}`);
+    updateLog(`normal ${START_ITALIC}italic${END_ITALIC} ${START_STRIKE}strike${END_STRIKE} ${START_BOLD}bold${END_BOLD} ${START_DIM}dim${END_DIM} ${highlightText('mark')} ${START_UNDERLINE}underline${END_UNDERLINE} ${linkText('Link', 'https://larn.org')} ${colorText('red', 'red')} ${colorText('green', 'green')} ${colorText('blue', 'blue')}`);
 
     // newcavelevel(level + 1);
     // setItem(player.x, player.y, createObject(OTRAPDOOR));

--- a/src/display.js
+++ b/src/display.js
@@ -160,10 +160,6 @@ function setDiv(id, data, markup) {
   if (markup === START_BOLD) {
     div.style.fontWeight = 'bold';
     div.style.color = 'white';
-  } else if (markup === START_MARK) {
-    div.style.color = 'black';
-    div.style.backgroundImage = 'none';
-    div.style.backgroundColor = 'lightgrey';
   } else if (markup === START_DIM) {
     div.style.color = 'grey';
   } else if (markup === START_STRIKE) {
@@ -175,6 +171,11 @@ function setDiv(id, data, markup) {
   } else if (markup && markup.indexOf(START_FONT) != -1) {
     // i.e. <font color='red'>
     div.style.color = markup.split(`'`)[1];
+  } else if (markup && markup.indexOf(START_MARK) != -1) {
+    // i.e. <mark style='background-color: red'>
+    div.style.color = 'black';
+    div.style.backgroundImage = 'none';
+    div.style.backgroundColor = markup.split(`'`)[1].split(`:`)[1];
   } else if (markup && markup.indexOf(START_HREF) != -1) {
     // i.e. <a href='link'>text</a> (must use ' not ")
     div.style.color = 'white';

--- a/src/display.js
+++ b/src/display.js
@@ -157,6 +157,8 @@ function setDiv(id, data, markup) {
 
   clearDivStyle(div);
 
+  if (!markup) return;
+
   if (markup === START_BOLD) {
     div.style.fontWeight = 'bold';
     div.style.color = 'white';
@@ -168,15 +170,15 @@ function setDiv(id, data, markup) {
     div.style.textDecoration = 'underline';
   } else if (markup === START_ITALIC) {
     div.style.fontStyle = 'italic';
-  } else if (markup && markup.indexOf(START_FONT) != -1) {
+  } else if (markup.indexOf(START_FONT) != -1) {
     // i.e. <font color='red'>
     div.style.color = markup.split(`'`)[1];
-  } else if (markup && markup.indexOf(START_MARK) != -1) {
+  } else if (markup.indexOf(START_MARK) != -1) {
     // i.e. <mark style='background-color: red'>
     div.style.color = 'black';
     div.style.backgroundImage = 'none';
     div.style.backgroundColor = markup.split(`'`)[1].split(`:`)[1];
-  } else if (markup && markup.indexOf(START_HREF) != -1) {
+  } else if (markup.indexOf(START_HREF) != -1) {
     // i.e. <a href='link'>text</a> (must use ' not ")
     div.style.color = 'white';
     div.style.cursor = 'pointer';

--- a/src/io.js
+++ b/src/io.js
@@ -5,7 +5,7 @@ let cursory = 1;
 
 let display = initGrid(80, 24);
 
-const START_MARK = `<mark>`;
+const START_MARK = `<mark style='background-color:`;
 const END_MARK = `</mark>`;
 const START_BOLD = `<b>`;
 const END_BOLD = `</b>`;
@@ -50,7 +50,6 @@ function lprcat(str) {
     // check for opening/closing markup tags. tags must be handled because 
     // they will use up characters in display[][] even though they aren't visible
     if (str.indexOf(START_BOLD, i) === i) starttag = START_BOLD;
-    else if (str.indexOf(START_MARK, i) === i) starttag = START_MARK;
     else if (str.indexOf(START_DIM, i) === i) starttag = START_DIM;
     else if (str.indexOf(START_STRIKE, i) === i) starttag = START_STRIKE;
     else if (str.indexOf(START_ITALIC, i) === i) starttag = START_ITALIC;
@@ -61,6 +60,10 @@ function lprcat(str) {
     }
     else if (str.indexOf(START_FONT, i) === i) {
       // <font color='red'>
+      starttag = str.slice(i, str.indexOf('>', i) + 1);
+    }
+    else if (str.indexOf(START_MARK, i) === i) {
+      // <mark style='background-color: red'>
       starttag = str.slice(i, str.indexOf('>', i) + 1);
     }
 

--- a/src/io.js
+++ b/src/io.js
@@ -24,6 +24,43 @@ const END_FONT = `</font>`;
 
 
 
+function startMark(color=``) {
+  if (color === ``) color = `lightgrey`;
+  return `${START_MARK}${color}'>`;
+}
+
+
+
+function wrapMark(str, color=``) {
+  return `${startMark(color)}${str}${END_MARK}`;
+}
+
+
+
+function startFont(color) {
+  return `${START_FONT}'${color}'>`;
+}
+
+
+
+function wrapFont(str, color) {
+  return `${startFont(color)}${str}${END_FONT}`;
+}
+
+
+
+function startHref(href) {
+  return `${START_HREF}'${href}'>`;
+}
+
+
+
+function wrapHref(str, href) {
+  return `${startHref(href)}${str}${END_HREF}`;
+}
+
+
+
 function lprint(str) {
   lprcat(str);
   blt();

--- a/src/io.js
+++ b/src/io.js
@@ -86,22 +86,11 @@ function lprcat(str) {
 
     // check for opening/closing markup tags. tags must be handled because 
     // they will use up characters in display[][] even though they aren't visible
-    if (str.indexOf(START_BOLD, i) === i) starttag = START_BOLD;
-    else if (str.indexOf(START_DIM, i) === i) starttag = START_DIM;
-    else if (str.indexOf(START_STRIKE, i) === i) starttag = START_STRIKE;
-    else if (str.indexOf(START_ITALIC, i) === i) starttag = START_ITALIC;
-    else if (str.indexOf(START_UNDERLINE, i) === i) starttag = START_UNDERLINE;
-    else if (str.indexOf(START_HREF, i) === i) {
-      // <a href='link'>text</a> (must use ' not ")
-      starttag = str.slice(i, str.indexOf('>', i) + 1);
-    }
-    else if (str.indexOf(START_FONT, i) === i) {
-      // <font color='red'>
-      starttag = str.slice(i, str.indexOf('>', i) + 1);
-    }
-    else if (str.indexOf(START_MARK, i) === i) {
-      // <mark style='background-color: red'>
-      starttag = str.slice(i, str.indexOf('>', i) + 1);
+    for (const tag of [START_BOLD, START_DIM, START_STRIKE, START_ITALIC, START_UNDERLINE, START_HREF, START_FONT, START_MARK]) {
+      if (str.indexOf(tag, i) === i) {
+        starttag = str.slice(i, str.indexOf('>', i) + 1);
+        break;
+      }
     }
 
     if (starttag) {
@@ -115,14 +104,12 @@ function lprcat(str) {
       // debug(`lprcat(): ${starttag}:${c}`)
     }
     
-    if (str.indexOf(END_BOLD, i+1) === i+1) endtag = END_BOLD;
-    else if (str.indexOf(END_MARK, i+1) === i+1) endtag = END_MARK;
-    else if (str.indexOf(END_DIM, i+1) === i+1) endtag = END_DIM;
-    else if (str.indexOf(END_STRIKE, i+1) === i+1) endtag = END_STRIKE;
-    else if (str.indexOf(END_ITALIC, i+1) === i+1) endtag = END_ITALIC;
-    else if (str.indexOf(END_UNDERLINE, i+1) === i+1) endtag = END_UNDERLINE;
-    else if (str.indexOf(END_FONT, i+1) === i+1) endtag = END_FONT;
-    else if (str.indexOf(END_HREF, i+1) === i+1) endtag = END_HREF;
+    for (const tag of [END_BOLD, END_DIM, END_STRIKE, END_ITALIC, END_UNDERLINE, END_HREF, END_FONT, END_MARK]) {
+      if (str.indexOf(tag, i+1) === i+1) {
+        endtag = tag;
+        break;
+      }
+    }
     
     if (endtag) {
       if (amiga_mode) {

--- a/src/io.js
+++ b/src/io.js
@@ -24,39 +24,22 @@ const END_FONT = `</font>`;
 
 
 
-function startMark(color=``) {
-  if (color === ``) color = `lightgrey`;
-  return `${START_MARK}${color}'>`;
+function highlightText(str, color) {
+  if (!color) color = `lightgrey`;
+  return `${START_MARK}${color}'>${str}${END_MARK}`;
 }
 
 
 
-function wrapMark(str, color=``) {
-  return `${startMark(color)}${str}${END_MARK}`;
+function colorText(str, color) {
+  if (!color) color = `lightgrey`;
+  return `${START_FONT}'${color}'>${str}${END_FONT}`;
 }
 
 
 
-function startFont(color) {
-  return `${START_FONT}'${color}'>`;
-}
-
-
-
-function wrapFont(str, color) {
-  return `${startFont(color)}${str}${END_FONT}`;
-}
-
-
-
-function startHref(href) {
-  return `${START_HREF}'${href}'>`;
-}
-
-
-
-function wrapHref(str, href) {
-  return `${startHref(href)}${str}${END_HREF}`;
+function linkText(str, href) {
+  return `${START_HREF}'${href}'>${str}${END_HREF}`;
 }
 
 

--- a/src/larn.css
+++ b/src/larn.css
@@ -103,7 +103,6 @@ div {
 }
 
 mark {
-    background-color: lightgrey;
     color: black;
 }
 

--- a/src/monster.js
+++ b/src/monster.js
@@ -146,7 +146,7 @@ Monster.prototype = {
   toString: function() {
     const monster = monsterlist[this.arg];
     if (player.BLINDCOUNT == 0) {
-      if (getPref('log_color') && monster.color) return `<font color='${monster.color}'>${monster.desc}</font>`;
+      if (getPref('log_color') && monster.color) return wrapFont(monster.desc, monster.color);
       else return monster.desc;
     }
     else {
@@ -179,7 +179,7 @@ Monster.prototype = {
         return OEMPTY.char;
       } else {
         if (getPref('show_color') && monsterlist[monster].color) {
-          return `<font color='${monsterlist[monster].color}'>${monsterlist[monster].char}</font>`;
+          return wrapFont(monsterlist[monster].char, monsterlist[monster].color);
         } else {
           return monsterlist[monster].char;
         }

--- a/src/monster.js
+++ b/src/monster.js
@@ -146,7 +146,7 @@ Monster.prototype = {
   toString: function() {
     const monster = monsterlist[this.arg];
     if (player.BLINDCOUNT == 0) {
-      if (getPref('log_color') && monster.color) return wrapFont(monster.desc, monster.color);
+      if (getPref('log_color') && monster.color) return colorText(monster.desc, monster.color);
       else return monster.desc;
     }
     else {
@@ -179,7 +179,7 @@ Monster.prototype = {
         return OEMPTY.char;
       } else {
         if (getPref('show_color') && monsterlist[monster].color) {
-          return wrapFont(monsterlist[monster].char, monsterlist[monster].color);
+          return colorText(monsterlist[monster].char, monsterlist[monster].color);
         } else {
           return monsterlist[monster].char;
         }

--- a/src/object.js
+++ b/src/object.js
@@ -337,7 +337,7 @@ class DungeonObject extends Item {
       char = this.hackchar;
     }
     if (getPref('show_color') && this.color) {
-      char = `<font color='${this.color}'>${char}</font>`;
+      char = wrapFont(char, this.color);
     }
     if (getPref('bold_objects') && this.bold) {
       char = `<b>${char}</b>`;

--- a/src/object.js
+++ b/src/object.js
@@ -337,7 +337,7 @@ class DungeonObject extends Item {
       char = this.hackchar;
     }
     if (getPref('show_color') && this.color) {
-      char = wrapFont(char, this.color);
+      char = colorText(char, this.color);
     }
     if (getPref('bold_objects') && this.bold) {
       char = `<b>${char}</b>`;

--- a/src/player.js
+++ b/src/player.js
@@ -135,7 +135,7 @@ var Player = function Player() {
   this.getChar = function () {
     if (amiga_mode) return `${DIV_START}player${DIV_END}`;
     if (this.char) return this.char;
-    if (getPref('retro_mode')) return `<b><font color='white'>@</font></b>`; 
+    if (getPref('retro_mode')) return `${START_BOLD}${wrapFont('@', 'white')}${END_BOLD}`;
     return `▓`;
   };
 

--- a/src/player.js
+++ b/src/player.js
@@ -616,9 +616,9 @@ var Player = function Player() {
 
     if (level == 0) this.TELEFLAG = 0;
     const hppad = this.HPMAX >= 100 ? 3 : 2;
-    const hpColor = this.HP >= this.HPMAX ? 'lightgrey'
-      : this.HP >= Math.floor(this.HPMAX * 2/3) ? 'lime'
-      : this.HP >= Math.floor(this.HPMAX / 3) ? 'yellow'
+    const hpColor = this.HP >= this.HPMAX ? ''
+      : this.HP >= Math.ceil(this.HPMAX * 2.0 / 3.0) ? 'lime'
+      : this.HP >= Math.ceil(this.HPMAX * 1.0 / 3.0) ? 'yellow'
       : 'red';
     const output =
       `Spells: ${pad(this.SPELLS,2,changedSpells)}(${pad(this.SPELLMAX,2,changedSpellsMax)})  \
@@ -626,7 +626,7 @@ AC: ${pad(this.AC,-4,changedAC)} \
 WC: ${pad(this.WCLASS,-4,changedWC)} \
 Level ${pad(this.LEVEL,-2,changedLevel)} \
 Exp: ${pad(this.EXPERIENCE,-10,changedExp)}${pad(CLASSES[this.LEVEL - 1],16,changedLevel)}               \n\
-HP: <font color='${hpColor}'>${pad(this.HP,hppad,changedHP)}</font>(${pad(this.HPMAX, hppad,changedHPMax)}) \
+HP: ${pad(this.HP,hppad,changedHP,hpColor)}(${pad(this.HPMAX,hppad,changedHPMax)}) \
 STR=${pad((this.STRENGTH + this.STREXTRA),-2,changedSTR)} \
 INT=${pad(this.INTELLIGENCE,-2,changedINT)} \
 WIS=${pad(this.WISDOM,-2, changedWIS)} \

--- a/src/player.js
+++ b/src/player.js
@@ -611,18 +611,22 @@ var Player = function Player() {
   // HP: 10(10)   STR=12 INT=12 WIS=12 CON=12 DEX=12 CHA=12 LV: H  Gold: 0
   this.getBottomLine = function(lev) {
     if (level < 0) return ``;
-    var templevel = LEVELNAMES[level];
+    let templevel = LEVELNAMES[level];
     if (lev) templevel = lev;
 
     if (level == 0) this.TELEFLAG = 0;
-    let hppad = this.HPMAX >= 100 ? 3 : 2;
-    var output =
+    const hppad = this.HPMAX >= 100 ? 3 : 2;
+    const hpColor = this.HP >= this.HPMAX ? 'lightgrey'
+      : this.HP >= Math.floor(this.HPMAX * 2/3) ? 'lime'
+      : this.HP >= Math.floor(this.HPMAX / 3) ? 'yellow'
+      : 'red';
+    const output =
       `Spells: ${pad(this.SPELLS,2,changedSpells)}(${pad(this.SPELLMAX,2,changedSpellsMax)})  \
 AC: ${pad(this.AC,-4,changedAC)} \
 WC: ${pad(this.WCLASS,-4,changedWC)} \
 Level ${pad(this.LEVEL,-2,changedLevel)} \
 Exp: ${pad(this.EXPERIENCE,-10,changedExp)}${pad(CLASSES[this.LEVEL - 1],16,changedLevel)}               \n\
-HP: ${pad(this.HP,hppad,changedHP)}(${pad(this.HPMAX, hppad,changedHPMax)}) \
+HP: <font color='${hpColor}'>${pad(this.HP,hppad,changedHP)}</font>(${pad(this.HPMAX, hppad,changedHPMax)}) \
 STR=${pad((this.STRENGTH + this.STREXTRA),-2,changedSTR)} \
 INT=${pad(this.INTELLIGENCE,-2,changedINT)} \
 WIS=${pad(this.WISDOM,-2, changedWIS)} \

--- a/src/player.js
+++ b/src/player.js
@@ -135,7 +135,7 @@ var Player = function Player() {
   this.getChar = function () {
     if (amiga_mode) return `${DIV_START}player${DIV_END}`;
     if (this.char) return this.char;
-    if (getPref('retro_mode')) return `${START_BOLD}${wrapFont('@', 'white')}${END_BOLD}`;
+    if (getPref('retro_mode')) return `${START_BOLD}${colorText('@', 'white')}${END_BOLD}`;
     return `▓`;
   };
 
@@ -616,25 +616,29 @@ var Player = function Player() {
 
     if (level == 0) this.TELEFLAG = 0;
     const hppad = this.HPMAX >= 100 ? 3 : 2;
-    const hpColor = this.HP >= this.HPMAX ? ''
+    const hpColor = (!getPref('log_color') || this.HP >= this.HPMAX) ? ''
       : this.HP >= Math.ceil(this.HPMAX * 2.0 / 3.0) ? 'lime'
       : this.HP >= Math.ceil(this.HPMAX * 1.0 / 3.0) ? 'yellow'
       : 'red';
+    const spellColor = (!getPref('log_color') || this.SPELLS >= this.SPELLMAX) ? ''
+      : this.SPELLS >= Math.ceil(this.SPELLMAX * 2.0 / 3.0) ? 'lime'
+      : this.SPELLS >= Math.ceil(this.SPELLMAX * 1.0 / 3.0) ? 'yellow'
+      : 'red';
     const output =
-      `Spells: ${pad(this.SPELLS,2,changedSpells)}(${pad(this.SPELLMAX,2,changedSpellsMax)})  \
-AC: ${pad(this.AC,-4,changedAC)} \
-WC: ${pad(this.WCLASS,-4,changedWC)} \
-Level ${pad(this.LEVEL,-2,changedLevel)} \
-Exp: ${pad(this.EXPERIENCE,-10,changedExp)}${pad(CLASSES[this.LEVEL - 1],16,changedLevel)}               \n\
-HP: ${pad(this.HP,hppad,changedHP,hpColor)}(${pad(this.HPMAX,hppad,changedHPMax)}) \
-STR=${pad((this.STRENGTH + this.STREXTRA),-2,changedSTR)} \
-INT=${pad(this.INTELLIGENCE,-2,changedINT)} \
-WIS=${pad(this.WISDOM,-2, changedWIS)} \
-CON=${pad(this.CONSTITUTION,-2,changedCON)} \
-DEX=${pad(this.DEXTERITY,-2,changedDEX)} \
-CHA=${pad(this.CHARISMA,-2,changedCHA)} \
-LV: ${pad((this.TELEFLAG ? `?` : templevel),-2,changedDepth)} \
-Gold: ${pad(Number(this.GOLD).toLocaleString(),1,changedGold)}            `;
+      `Spells: ${pad(this.SPELLS, 2, changedSpells, spellColor)}(${pad(this.SPELLMAX, 2, changedSpellsMax)})  \
+AC: ${pad(this.AC, -4, changedAC)} \
+WC: ${pad(this.WCLASS, -4, changedWC)} \
+Level ${pad(this.LEVEL, -2, changedLevel)} \
+Exp: ${pad(this.EXPERIENCE, -10, changedExp)}${pad(CLASSES[this.LEVEL - 1], 16, changedLevel)}               \n\
+HP: ${pad(this.HP, hppad, changedHP, hpColor)}(${pad(this.HPMAX, hppad, changedHPMax)}) \
+STR=${pad((this.STRENGTH + this.STREXTRA), -2, changedSTR)} \
+INT=${pad(this.INTELLIGENCE, -2, changedINT)} \
+WIS=${pad(this.WISDOM, -2, changedWIS)} \
+CON=${pad(this.CONSTITUTION, -2, changedCON)} \
+DEX=${pad(this.DEXTERITY, -2, changedDEX)} \
+CHA=${pad(this.CHARISMA, -2, changedCHA)} \
+LV: ${pad((this.TELEFLAG ? `?` : templevel), -2, changedDepth)} \
+Gold: ${pad(Number(this.GOLD).toLocaleString(), 1, changedGold)}            `;
 
     return output;
   }; //


### PR DESCRIPTION
Color codes the HP readout according to the fraction of max HP:

- White: full HP
- Green: >= 2/3 HP
- Yellow: >= 1/3 HP
- Red: < 1/3 HP

<img width="983" height="182" alt="image" src="https://github.com/user-attachments/assets/7fc2a489-5e0b-4b9e-b684-bcc3b37bc658" />

Ideally this would change the background highlight too, but that would be a bigger change since `<mark>` doesn't accept a custom background color AFAICT. Therefore, I figured I'd send this in as a draft for feedback before attempting to change that.

This could also be extended to spells if we want to. Not sure if we'd want to use the same colors and thresholds or something different.