### PR TITLE
Show item symbol next to name in inventory

### DIFF
--- a/src/inventory.js
+++ b/src/inventory.js
@@ -23,7 +23,7 @@ function showinventory(select_allowed, callback, inv_filter, show_gold, show_tim
   if (show_gold) {
     if (p.GOLD) {
       if (printScreen) cltoeoln();
-      if (printScreen) lprcat(`.) ${Number(p.GOLD).toLocaleString()} gold pieces\n`);
+      if (printScreen) lprcat(`.) ${OGOLDPILE.getChar()} ${Number(p.GOLD).toLocaleString()} gold pieces\n`);
       srcount++;
     } else {
       show_gold = false;
@@ -43,13 +43,13 @@ function showinventory(select_allowed, callback, inv_filter, show_gold, show_tim
       srcount++;
       if (srcount <= wrap) {
         if (printScreen) cltoeoln();
-        widest = Math.max(widest, item.toString().length + 5);
+        widest = Math.max(widest, item.toString().length + 7);
       } else {
         let extra = show_gold ? 1 : 0;
         if (printScreen) cursor(widest, srcount % wrap + extra);
       }
       let foo = p.inventory.indexOf(item);
-      if (printScreen) lprcat(`${getCharFromIndex(foo)}) ${item}\n`);
+      if (printScreen) lprcat(`${getCharFromIndex(foo)}) ${item.getChar()} ${item}\n`);
       buttons.push([getCharFromIndex(foo), item]);
     }
   }

--- a/src/inventory.js
+++ b/src/inventory.js
@@ -23,7 +23,8 @@ function showinventory(select_allowed, callback, inv_filter, show_gold, show_tim
   if (show_gold) {
     if (p.GOLD) {
       if (printScreen) cltoeoln();
-      if (printScreen) lprcat(`.) ${OGOLDPILE.getChar()} ${Number(p.GOLD).toLocaleString()} gold pieces\n`);
+      const goldSymbol = amiga_mode ? `` : `${OGOLDPILE.getChar()} `;
+      if (printScreen) lprcat(`.) ${goldSymbol}${Number(p.GOLD).toLocaleString()} gold pieces\n`);
       srcount++;
     } else {
       show_gold = false;
@@ -41,15 +42,18 @@ function showinventory(select_allowed, callback, inv_filter, show_gold, show_tim
     let item = inventory[k];
     if (inv_filter(item)) {
       srcount++;
+      const itemSymbol = amiga_mode ? `` : `${item.getChar()} `;
+      const itemStr = `${itemSymbol}${item}`;
       if (srcount <= wrap) {
         if (printScreen) cltoeoln();
-        widest = Math.max(widest, item.toString().length + 7);
+        let itemWidth = itemStr.length + 5;
+        widest = Math.max(widest, itemWidth);
       } else {
         let extra = show_gold ? 1 : 0;
         if (printScreen) cursor(widest, srcount % wrap + extra);
       }
       let foo = p.inventory.indexOf(item);
-      if (printScreen) lprcat(`${getCharFromIndex(foo)}) ${item.getChar()} ${item}\n`);
+      if (printScreen) lprcat(`${getCharFromIndex(foo)}) ${itemStr}\n`);
       buttons.push([getCharFromIndex(foo), item]);
     }
   }

--- a/src/player.js
+++ b/src/player.js
@@ -1087,13 +1087,13 @@ function game_stats(p, endgame) {
   var s = endgame ? `Inventory:\n` : ``;
 
   if (endgame) {
-    s += `.) ` + Number(p.GOLD).toLocaleString() + ` gold pieces\n`;
+    s += `.) ${OGOLDPILE.getChar()} ` + Number(p.GOLD).toLocaleString() + ` gold pieces\n`;
   }
   var inv = showinventory(false, null, showall, false, false, false, p); //HACK!
   for (var i = 0; i < inv.length; i++) {
     var item = inv[i][1];
     if (item) {
-      let itemString = inv[i][0] + `) ` + item.toString(false, endgame || DEBUG_STATS, p);
+      let itemString = inv[i][0] + `) ${item.getChar()} ` + item.toString(false, endgame || DEBUG_STATS, p);
       let itemParts = [itemString];
       if (itemString.length > 39)
         itemParts = itemString.split(`(`);

--- a/src/player.js
+++ b/src/player.js
@@ -1087,13 +1087,15 @@ function game_stats(p, endgame) {
   var s = endgame ? `Inventory:\n` : ``;
 
   if (endgame) {
-    s += `.) ${OGOLDPILE.getChar()} ` + Number(p.GOLD).toLocaleString() + ` gold pieces\n`;
+    let goldSymbol = amiga_mode ? `` : `${OGOLDPILE.getChar()} `;
+    s += `.) ${goldSymbol}` + Number(p.GOLD).toLocaleString() + ` gold pieces\n`;
   }
   var inv = showinventory(false, null, showall, false, false, false, p); //HACK!
   for (var i = 0; i < inv.length; i++) {
     var item = inv[i][1];
     if (item) {
-      let itemString = inv[i][0] + `) ${item.getChar()} ` + item.toString(false, endgame || DEBUG_STATS, p);
+      let itemSymbol = amiga_mode ? `` : `${item.getChar()} `;
+      let itemString = inv[i][0] + `) ${itemSymbol}` + item.toString(false, endgame || DEBUG_STATS, p);
       let itemParts = [itemString];
       if (itemString.length > 39)
         itemParts = itemString.split(`(`);


### PR DESCRIPTION
Shows each item's symbol next to its name in the inventory (both sidebar and dedicated inventory menu), just as it would appear on the map.

Let me know if you'd prefer for this to be an optional setting.

### Sidebar
<img width="365" height="527" alt="screenshot_20260718_111535" src="https://github.com/user-attachments/assets/f1feb985-f309-42ed-90a3-19ddb66535c2" />

### Inventory menu
<img width="584" height="418" alt="screenshot_20260718_111616" src="https://github.com/user-attachments/assets/de3a7dfd-0ca3-43eb-8f0c-bb8c0bf393af" />
